### PR TITLE
Change default call to action copy

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -12,7 +12,7 @@
       </h1>
       <p>See a variety of different USWDS components that can be used on site pages.</p>
       <a class="usa-button usa-button--outline usa-button--inverse" href="https://www.dhs.gov/xlibrary/dhsweb/_site/components.html">
-        Call to action
+        Go to the components
       </a>
     </div>
   </div>


### PR DESCRIPTION
- Changes boilerplate hero "button" copy from `Call to action` to `Go to the components`